### PR TITLE
minimal change to get lcm python package built and installed

### DIFF
--- a/lcm-1.0.0/CMakeLists.txt
+++ b/lcm-1.0.0/CMakeLists.txt
@@ -57,8 +57,10 @@ if (JAVA_FOUND)
   add_subdirectory(lcm-java)
 endif()
 
-# todo: add "if python" logic
-#add_subdirectory(lcm-python)
+find_package(PythonInterp)
+if (PYTHONINTERP_FOUND)
+  add_subdirectory(lcm-python)
+endif()
 
 # todo: add "if lua" logic
 #add_subdirectory(lcm-lua)

--- a/lcm-1.0.0/lcm-python/CMakeLists.txt
+++ b/lcm-1.0.0/lcm-python/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_custom_target(install_python ALL
-	COMMAND time ${PYTHON_EXECUTABLE} setup.py build --build-base=${CMAKE_CURRENT_BINARY_DIR} install --prefix=${CMAKE_INSTALL_PREFIX} 
+	COMMAND time ${PYTHON_EXECUTABLE} setup.py build --build-base=${CMAKE_CURRENT_BINARY_DIR} 
+	build_ext --include-dirs="${CMAKE_BINARY_DIR}/include" --library-dirs="${CMAKE_BINARY_DIR}/lib"
+	install --prefix=${CMAKE_INSTALL_PREFIX}
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/lcm-1.0.0/lcm-python/CMakeLists.txt
+++ b/lcm-1.0.0/lcm-python/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_custom_target(install_python ALL
-	COMMAND python setup.py build --build-base=${CMAKE_CURRENT_BINARY_DIR} install --prefix=${CMAKE_INSTALL_PREFIX} 
+	COMMAND time ${PYTHON_EXECUTABLE} setup.py build --build-base=${CMAKE_CURRENT_BINARY_DIR} install --prefix=${CMAKE_INSTALL_PREFIX} 
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/lcm-1.0.0/lcm-python/CMakeLists.txt
+++ b/lcm-1.0.0/lcm-python/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_custom_target(install_python ALL
+	COMMAND python setup.py build --build-base=${CMAKE_CURRENT_BINARY_DIR} install --prefix=${CMAKE_INSTALL_PREFIX} 
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This just dispatches to the python installer that was already distributed with LCM. We could always recreate their installation process in pure cmake, but this works and should be easy to apply on top of later versions of LCM. The only downside I'm aware of is that it re-runs setup.py each time the pod is built, but that takes a grand total of about 100ms on my laptop. 

