### PR TITLE
Fix the windows build when python is enabled.

### DIFF
--- a/lcm-1.0.0/CMakeLists.txt
+++ b/lcm-1.0.0/CMakeLists.txt
@@ -49,7 +49,7 @@ if (JAVA_FOUND)
 endif()
 
 find_package(PythonInterp)
-if (PYTHONINTERP_FOUND AND NOT WIN32)
+if (PYTHONINTERP_FOUND)
   add_subdirectory(lcm-python)
 endif()
 

--- a/lcm-1.0.0/lcm-python/CMakeLists.txt
+++ b/lcm-1.0.0/lcm-python/CMakeLists.txt
@@ -1,5 +1,8 @@
+# setup.py needs this path to be in native format or it will drop the path separator
+# after the drive letter.
+file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}" INSTALL_PREFIX)
 add_custom_target(install_python ALL
-	COMMAND ${PYTHON_EXECUTABLE} setup.py build --build-base=${CMAKE_CURRENT_BINARY_DIR} 
+	COMMAND ${PYTHON_EXECUTABLE} setup.py build --build-base=${CMAKE_CURRENT_BINARY_DIR}
 	build_ext --include-dirs="${CMAKE_BINARY_DIR}/include" --library-dirs="${CMAKE_BINARY_DIR}/lib"
-	install --prefix=${CMAKE_INSTALL_PREFIX}
+	install --prefix=${INSTALL_PREFIX}
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/lcm-1.0.0/lcm-python/setup.py
+++ b/lcm-1.0.0/lcm-python/setup.py
@@ -22,10 +22,16 @@ libraries = []
 extra_compile_args = []
 
 if os.name == 'nt':
-    # check for GLIB_PATH environment var, exit with error if not found
+    # if VS90COMNTOOLS is not set set it to the value of VS140COMNTOOLS
+    vs90tools = os.getenv('VS90COMNTOOLS')
+    if not vs90tools:
+        os.environ['VS90COMNTOOLS'] = os.getenv('VS140COMNTOOLS')
+    # check for GLIB_PATH environment var
+    # if not set assume we are in externals/lcm/lcm-version/pod-build
+    # and use that to get to externals/gtk/gtk3
     glibPath = os.getenv('GLIB_PATH')
     if not glibPath:
-        sys.exit('GLIB_PATH environment variable not set.')
+        glibPath = os.path.realpath(os.path.join("..", "..", "..", "gtk", "gtk3"))
 
     include_dirs = [ \
             "..",
@@ -51,7 +57,7 @@ if os.name == 'nt':
     msvccompiler.MSVCCompiler._c_extensions = []
     msvccompiler.MSVCCompiler._cpp_extensions.append('.c')
 
-    sources.append(os.path.join("..", "WinSpecific", "WinPorting.cpp"))
+    sources.append(os.path.join("..", "lcm", "windows", "WinPorting.cpp"))
 
 else:
     pkg_deps = "glib-2.0 gthread-2.0"


### PR DESCRIPTION
This will only work with 64bit builds because the gtk in externals
is 64 bit. However, if 32 bit was needed it should be an easy fix.
This also depends on VS14 see lcm-1.0.0/lcm-python/setup.py where
that is set to use VS140COMNTOOLS. A future version of VS could
be used if the env var VS90COMNTOOLS was set to that versions
comntools env var.  This is also setup to work with Python2.7 64 bit.