### PR TITLE
Add a check to make sure the python found is 64.

### DIFF
--- a/lcm-1.0.0/CMakeLists.txt
+++ b/lcm-1.0.0/CMakeLists.txt
@@ -49,8 +49,35 @@ if (JAVA_FOUND)
 endif()
 
 find_package(PythonInterp)
+message("hello ${PYTHONINTERP_FOUND}")
 if (PYTHONINTERP_FOUND)
-  add_subdirectory(lcm-python)
+  set(pythonOK TRUE)
+  if(WIN32)
+    execute_process(
+      COMMAND "${PYTHON_EXECUTABLE}" -c
+      "import platform; print( platform.architecture()[0])"
+      OUTPUT_VARIABLE PYTHON_ARCH
+      RESULT_VARIABLE _PYTHON_ARCH_RESULT
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    if(_PYTHON_ARCH_RESULT EQUAL 0)
+      if(NOT "${PYTHON_ARCH}" MATCHES "64bit")
+        set(pythonOK FALSE)
+        message(STATUS
+          "lcm-python disabled becuase python is not 64bit but is:"
+          " ${PYTHON_ARCH}")
+      else()
+        message(STATUS "lcm-python enabled 64 bit python found.")
+      endif()
+    else()
+      message(STATUS
+          "lcm-python disabled becuase can not determine python arch.")
+        set(pythonOK FALSE)
+    endif()
+  endif()
+  if(pythonOK)
+    add_subdirectory(lcm-python)
+  endif()
 endif()
 
 # todo: add "if lua" logic


### PR DESCRIPTION
 @RussTedrake This commit will make it so that only a 64bit python on windows will enable lcm-python since that is the only one that compiles.  This should fix the Appveyor issue.