### PR TITLE
Use dummy install logic instead of custom target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,4 @@ ExternalProject_Add_Step(lcm forceconfigure
 	DEPENDERS configure
 	ALWAYS 1)
 
-# Tell cmake to let us create "install" target
-cmake_policy(SET CMP0037 OLD)
-add_custom_target(install DEPENDS lcm)  # just to have an explicit install rule
+install(CODE "message(\"Nothing to do for install.\")")


### PR DESCRIPTION
Use `install(CODE ...)` to add some no-op install logic in order to trigger CMake to generate an install target. This is a little cleaner than creating a custom target with a reserved name, and in particular does not require fiddling with a CMake policy. (Critically, the policy was missing a version check, and so was failing on older CMake.)